### PR TITLE
Add AwaitResult() at end

### DIFF
--- a/Set-LockscreenWallpaper/Set-LockscreenWallpaper.ps1
+++ b/Set-LockscreenWallpaper/Set-LockscreenWallpaper.ps1
@@ -7,4 +7,7 @@ function Set-LockscreenWallpaper($path) {
 	$file = $wrapper.AwaitResult()
 	$null = [Windows.System.UserProfile.LockScreen,Windows.System.UserProfile,ContentType=WindowsRuntime]
 	[Windows.System.UserProfile.LockScreen]::SetImageFileAsync($file)
+	$typeName = 'PoshWinRT.AsyncActionWrapper'
+        $wrapper = new-object $typeName -Arg $asyncOp
+        $wrapper.AwaitResult()
 }


### PR DESCRIPTION
First, thanks for figuring this out. I tried a couple different ways but this is the way that works consistently. 

I was having trouble running this inside a scheduled task and a `Sleep 3` at the end of the function seemed to fix the problem, so I thought maybe the last async call wasn't finishing in time. This adds a blocking `AwaitResult()` call at the end and there's a PR [here](https://github.com/rkeithhill/PoshWinRT/pull/2) for addition of the `AsyncActionWrapper` class to the PoshWinRT minilibrary.